### PR TITLE
BE hotfix 검색 API, 그룹 스터디 정보 조회 API 수정

### DIFF
--- a/server/src/main/java/com/inha/server/study/group/dto/response/GetGroupStudyInfoRes.java
+++ b/server/src/main/java/com/inha/server/study/group/dto/response/GetGroupStudyInfoRes.java
@@ -20,4 +20,5 @@ public class GetGroupStudyInfoRes {
   private String introduction;
   private String groupDuration;
   private String ownerId;
+  private String createdAt;
 }

--- a/server/src/main/java/com/inha/server/study/group/service/GroupStudyService.java
+++ b/server/src/main/java/com/inha/server/study/group/service/GroupStudyService.java
@@ -105,6 +105,9 @@ public class GroupStudyService {
 
     @Transactional
     public ResponseEntity<GetGroupStudyListRes> search(String keyword, Pageable pageable) {
+        if (Objects.equals(keyword, "")) {
+            return getGroupStudyList(pageable);
+        }
         List<GroupStudy> groupStudyList = groupStudyRepository.findByGroupNameContainingIgnoreCase(
             keyword);
         List<GroupStudy> groupStudyListWithPageable = groupStudyRepository.findByGroupNameContainingIgnoreCase(
@@ -350,6 +353,7 @@ public class GroupStudyService {
             .introduction(groupStudy.getIntroduction())
             .groupDuration(groupStudy.getGroupDuration())
             .ownerId(groupStudy.getOwnerId())
+            .createdAt(groupStudy.getCreatedAt())
             .build(), HttpStatus.OK);
     }
 }


### PR DESCRIPTION
## 개요
- #177 

## 작업사항
- 검색 키워드가 빈 문자열일 때 전체 리스트가 조회되도록 예외처리
- 그룹 스터디 정보 조회시 리스폰스에 createdAt이 포함되도록 예외처리
